### PR TITLE
Resolves: #1574410 Incorrect lowercase Cyrillic BE for Macedonian language

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+* Tue Sep 18 2018 Vishal Vijayraghavan <vishalvijayraghavan@gmail.com>
+- Resolved #1574410:  Incorrect lowercase Cyrillic BE for Macedonian language in liberation v2 (look like Greek delta)
+- Patch fix by Dimitrij Mijoski: https://pagure.io/liberation-fonts/pull-request/21
+- Updated LiberationMono-Bold, LiberationMono-Regular, LiberationSans-Bold, LiberationSans-Regular, LiberationSerif-Bold, LiberationSerif-Regular
+
 * Thu May 17 2018 Pravin Satpute <psatpute AT redhat DOT com> - 2.00.3
 - Releasing liberation-fonts 2.00.3 version, it includes fix for few bugs.
 - This release was pending from long time, will work on other open bugs

--- a/src/LiberationMono-Bold.sfd
+++ b/src/LiberationMono-Bold.sfd
@@ -53,7 +53,6 @@ OS2FamilyClass: 2053
 OS2Vendor: '1ASC'
 OS2CodePages: 600001bf.dff70000
 OS2UnicodeRanges: e0000aff.400078ff.00000001.00000000
-Lookup: 1 0 0 "'locl' Localized Forms lookup 4"  {"'locl' Localized Forms lookup 4-1"  } ['locl' ('cyrl' <'SRB ' > 'cyrl' <'MKD ' > ) ]
 Lookup: 4 1 0 "'dlig' Discretionary Ligatures in Hebrew lookup 0"  {"'dlig' Discretionary Ligatures in Hebrew lookup 0 subtable"  } ['dlig' ('hebr' <'dflt' > ) ]
 Lookup: 4 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
 Lookup: 6 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
@@ -48053,7 +48052,6 @@ SplineSet
  315 869 315 869 421.5 948 c 128,-1,35
  528 1027 528 1027 685 1027 c 0,11,12
 EndSplineSet
-Substitution2: "'locl' Localized Forms lookup 4-1" S_BE
 EndChar
 
 StartChar: uni0432

--- a/src/LiberationMono-Regular.sfd
+++ b/src/LiberationMono-Regular.sfd
@@ -53,7 +53,6 @@ OS2FamilyClass: 2053
 OS2Vendor: '1ASC'
 OS2CodePages: 600001bf.dff70000
 OS2UnicodeRanges: e0000aff.400078ff.00000001.00000000
-Lookup: 1 0 0 "'locl' Localized Forms lookup 4"  {"'locl' Localized Forms lookup 4-1"  } ['locl' ('cyrl' <'SRB ' > 'cyrl' <'MKD ' > ) ]
 Lookup: 4 1 0 "'dlig' Discretionary Ligatures in Hebrew lookup 0"  {"'dlig' Discretionary Ligatures in Hebrew lookup 0 subtable"  } ['dlig' ('hebr' <'dflt' > ) ]
 Lookup: 4 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
 Lookup: 6 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
@@ -48004,7 +48003,6 @@ SplineSet
  332 890 332 890 433 958.5 c 128,-1,37
  534 1027 534 1027 675 1027 c 0,12,13
 EndSplineSet
-Substitution2: "'locl' Localized Forms lookup 4-1" S_BE
 EndChar
 
 StartChar: uni0432

--- a/src/LiberationSans-Bold.sfd
+++ b/src/LiberationSans-Bold.sfd
@@ -53,7 +53,6 @@ OS2FamilyClass: 2053
 OS2Vendor: '1ASC'
 OS2CodePages: 600001bf.dff70000
 OS2UnicodeRanges: e0000aff.500078ff.00000021.00000000
-Lookup: 1 0 0 "'locl' Localized Forms lookup 5"  {"'locl' Localized Forms lookup 5-1"  } ['locl' ('cyrl' <'SRB ' > 'cyrl' <'MKD ' > ) ]
 Lookup: 4 1 0 "'dlig' Discretionary Ligatures in Hebrew lookup 0"  {"'dlig' Discretionary Ligatures in Hebrew lookup 0 subtable"  } ['dlig' ('hebr' <'dflt' > ) ]
 Lookup: 4 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
 Lookup: 6 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
@@ -62928,7 +62927,6 @@ SplineSet
  362 1027 362 1027 697 1027 c 0,12,13
 EndSplineSet
 Kerns2: 628 -27 "'kern' Horizontal Kerning lookup 17 subtable"  626 -27 "'kern' Horizontal Kerning lookup 17 subtable"  623 -27 "'kern' Horizontal Kerning lookup 17 subtable"  620 -51 "'kern' Horizontal Kerning lookup 17 subtable"  618 -51 "'kern' Horizontal Kerning lookup 17 subtable"  616 -27 "'kern' Horizontal Kerning lookup 17 subtable"  614 -27 "'kern' Horizontal Kerning lookup 17 subtable"  609 -27 "'kern' Horizontal Kerning lookup 17 subtable"  608 -51 "'kern' Horizontal Kerning lookup 17 subtable"  604 -27 "'kern' Horizontal Kerning lookup 17 subtable"  603 -27 "'kern' Horizontal Kerning lookup 17 subtable"  601 -51 "'kern' Horizontal Kerning lookup 17 subtable" 
-Substitution2: "'locl' Localized Forms lookup 5-1" S_BE
 EndChar
 
 StartChar: uni0432

--- a/src/LiberationSans-Regular.sfd
+++ b/src/LiberationSans-Regular.sfd
@@ -53,7 +53,6 @@ OS2FamilyClass: 2053
 OS2Vendor: '1ASC'
 OS2CodePages: 600001bf.dff70000
 OS2UnicodeRanges: e0000aff.500078ff.00000021.00000000
-Lookup: 1 0 0 "'locl' Localized Forms lookup 5"  {"'locl' Localized Forms lookup 5-1"  } ['locl' ('cyrl' <'SRB ' > 'cyrl' <'MKD ' > ) ]
 Lookup: 4 1 0 "'dlig' Discretionary Ligatures in Hebrew lookup 0"  {"'dlig' Discretionary Ligatures in Hebrew lookup 0 subtable"  } ['dlig' ('hebr' <'dflt' > ) ]
 Lookup: 4 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
 Lookup: 6 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
@@ -59480,7 +59479,6 @@ SplineSet
  511 1027 511 1027 655 1027 c 0,12,13
 EndSplineSet
 Kerns2: 628 -45 "'kern' Horizontal Kerning lookup 17 subtable"  626 -23 "'kern' Horizontal Kerning lookup 17 subtable"  623 -68 "'kern' Horizontal Kerning lookup 17 subtable"  620 -68 "'kern' Horizontal Kerning lookup 17 subtable"  618 -68 "'kern' Horizontal Kerning lookup 17 subtable"  617 -23 "'kern' Horizontal Kerning lookup 17 subtable"  616 -45 "'kern' Horizontal Kerning lookup 17 subtable"  614 -23 "'kern' Horizontal Kerning lookup 17 subtable"  609 -45 "'kern' Horizontal Kerning lookup 17 subtable"  608 -92 "'kern' Horizontal Kerning lookup 17 subtable"  604 -45 "'kern' Horizontal Kerning lookup 17 subtable"  603 -23 "'kern' Horizontal Kerning lookup 17 subtable"  602 -23 "'kern' Horizontal Kerning lookup 17 subtable"  601 -92 "'kern' Horizontal Kerning lookup 17 subtable"  597 -47 "'kern' Horizontal Kerning lookup 17 subtable" 
-Substitution2: "'locl' Localized Forms lookup 5-1" S_BE
 EndChar
 
 StartChar: uni0432

--- a/src/LiberationSerif-Bold.sfd
+++ b/src/LiberationSerif-Bold.sfd
@@ -53,7 +53,6 @@ OS2FamilyClass: 261
 OS2Vendor: '1ASC'
 OS2CodePages: 600001bf.dff70000
 OS2UnicodeRanges: e0000aff.500078ff.00000021.00000000
-Lookup: 1 0 0 "'locl' Localized Forms lookup 5"  {"'locl' Localized Forms lookup 5-1"  } ['locl' ('cyrl' <'SRB ' > 'cyrl' <'MKD ' > ) ]
 Lookup: 4 1 0 "'dlig' Discretionary Ligatures in Hebrew lookup 0"  {"'dlig' Discretionary Ligatures in Hebrew lookup 0 subtable"  } ['dlig' ('hebr' <'dflt' > ) ]
 Lookup: 4 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
 Lookup: 6 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
@@ -60706,7 +60705,6 @@ SplineSet
  656 253 656 253 656 475 c 0,26,27
 EndSplineSet
 Kerns2: 629 -51 "'kern' Horizontal Kerning lookup 16 subtable"  624 -51 "'kern' Horizontal Kerning lookup 16 subtable"  621 -78 "'kern' Horizontal Kerning lookup 16 subtable"  619 -78 "'kern' Horizontal Kerning lookup 16 subtable"  617 -78 "'kern' Horizontal Kerning lookup 16 subtable"  612 -27 "'kern' Horizontal Kerning lookup 16 subtable"  610 -41 "'kern' Horizontal Kerning lookup 16 subtable"  609 -51 "'kern' Horizontal Kerning lookup 16 subtable"  604 -51 "'kern' Horizontal Kerning lookup 16 subtable"  603 -27 "'kern' Horizontal Kerning lookup 16 subtable"  602 -51 "'kern' Horizontal Kerning lookup 16 subtable" 
-Substitution2: "'locl' Localized Forms lookup 5-1" S_BE
 EndChar
 
 StartChar: uni0432

--- a/src/LiberationSerif-Regular.sfd
+++ b/src/LiberationSerif-Regular.sfd
@@ -53,7 +53,6 @@ OS2FamilyClass: 261
 OS2Vendor: '1ASC'
 OS2CodePages: 600001bf.dff70000
 OS2UnicodeRanges: e0000aff.500078ff.00000021.00000000
-Lookup: 1 0 0 "'locl' Localized Forms lookup 5"  {"'locl' Localized Forms lookup 5-1"  } ['locl' ('cyrl' <'SRB ' > 'cyrl' <'MKD ' > ) ]
 Lookup: 4 1 0 "'dlig' Discretionary Ligatures in Hebrew lookup 0"  {"'dlig' Discretionary Ligatures in Hebrew lookup 0 subtable"  } ['dlig' ('hebr' <'dflt' > ) ]
 Lookup: 4 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 1 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
 Lookup: 6 1 0 "'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2"  {"'ccmp' Glyph Composition/Decomposition in Hebrew lookup 2 subtable"  } ['ccmp' ('hebr' <'dflt' > ) ]
@@ -71697,7 +71696,6 @@ SplineSet
  784 255 784 255 784 475 c 0,29,30
 EndSplineSet
 Kerns2: 629 -51 "'kern' Horizontal Kerning lookup 16 subtable"  624 -51 "'kern' Horizontal Kerning lookup 16 subtable"  621 -78 "'kern' Horizontal Kerning lookup 16 subtable"  619 -78 "'kern' Horizontal Kerning lookup 16 subtable"  617 -78 "'kern' Horizontal Kerning lookup 16 subtable"  610 -20 "'kern' Horizontal Kerning lookup 16 subtable"  609 -51 "'kern' Horizontal Kerning lookup 16 subtable"  604 -51 "'kern' Horizontal Kerning lookup 16 subtable"  603 -27 "'kern' Horizontal Kerning lookup 16 subtable"  602 -51 "'kern' Horizontal Kerning lookup 16 subtable" 
-Substitution2: "'locl' Localized Forms lookup 5-1" S_BE
 EndChar
 
 StartChar: uni0432


### PR DESCRIPTION
Resolves: #1574410 Incorrect lowercase Cyrillic BE for Macedonian language in liberation v2 (look like Greek delta)