### PR TITLE
fix makefile clean function & add install function for packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,12 @@ clean: clean-dist
 	rm -rf -- $(DISTPREFIX)* $(DISTPREFIX_TTF)*
 	rm -rf -- $(EXPORTDIR)
 	rm -f -- $(CHECK_PREFIX)_*
+	rm -f src/*.ttf 
 clean-dist:
 	rm -f -- *.tar.gz *.zip
+	
+install:
+	mkdir -p $(DESTDIR)/usr/share/fonts/$(DISTPREFIX_TTF) || true
+	install $(DISTPREFIX_TTF)/* $(DESTDIR)/usr/share/fonts/$(DISTPREFIX_TTF)
 
 .PHONY: all build ttf-dir ttf dist dist-src dist-sfd dist-ttf 4web $(FORMATS) check clean clean-dist


### PR DESCRIPTION
Most of package manager use `make && make install DESTDIR=/path/to/dir`. I added `make install` in makefile. 

Also make clean funtion didn't clean built ttf files in src directory.

I think this pull request is absolutelly essential.