### PR TITLE
Fix OS/2.yStrikeoutPosition in LiberationSerif-Regular

### DIFF
--- a/src/LiberationSerif-Regular.sfd
+++ b/src/LiberationSerif-Regular.sfd
@@ -49,7 +49,7 @@ OS2SupYSize: 1331
 OS2SupXOff: 0
 OS2SupYOff: 928
 OS2StrikeYSize: 100
-OS2StrikeYPos: 420
+OS2StrikeYPos: 530
 OS2FamilyClass: 261
 OS2Vendor: '1ASC'
 OS2CodePages: 600001bf.dff70000


### PR DESCRIPTION
Use the same position as the other fonts.

Fixes https://github.com/liberationfonts/liberation-fonts/issues/58